### PR TITLE
opensource terraform core modules to support DPAS processing cloud setup on AWS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,11 @@
+.idea
+
+.terraform
+terraform.tfstate*
+.terraform.lock.hcl
+
+*.pem
+*.crt
+*.key
+.DS_Store
+*.tgz

--- a/README.md
+++ b/README.md
@@ -5,3 +5,15 @@ Collection of Terraform AWS modules supported by GeoScience DPAS team.
 This repository manages Terraform AWS modules to setup a production scale kubernetes cluster and supported resources
 for running Data Processing and Archival System for Satellite Cross-Calibration Radiometer (SCR) missions.
 
+## Getting started
+Follow our [Getting Started Guide](example/README.md) to deploy your first cluster and learn how to customise your build.
+
+## License
+Apache 2 Licensed. See [LICENSE](LICENSE) for full details.
+
+## References
+- [datacube-k8s-eks Open Data Cube (ODC) terraform modules](https://github.com/opendatacube/datacube-k8s-eks)
+- [terraform-aws-modules community modules](https://github.com/terraform-aws-modules)
+- [Flux2 Community Helm Charts](https://github.com/fluxcd-community/helm-charts)
+- [Karpenter Helm Charts](https://github.com/aws/karpenter/tree/main/charts/karpenter)
+- [Kubernetes Role Based Access Control with Service Account](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/)

--- a/backend_init/README.md
+++ b/backend_init/README.md
@@ -1,0 +1,44 @@
+# Terraform Module: backend_init
+
+The purpose of this module is to provision backend resources to manage DPAS terraform state files.
+
+---
+
+## Introduction
+
+The module provisions the following resource:
+
+- Terraform backend s3 and dynamodb resources to manage terraform state
+
+## Usage
+
+```hcl-terraform
+module "backend_init" {
+  source = "git@github.com:ga-scr/dpas-terraform-modules.git//backend_init?ref=main"
+
+  owner       = local.owner
+  namespace   = local.namespace
+  environment = local.environment
+
+  # Additional Tags
+  tags = local.tags
+}
+```
+
+## Variables
+
+### Inputs
+| Name        | Description                                                                                                 |     Type     | Default | Required |
+|-------------|-------------------------------------------------------------------------------------------------------------|:------------:|:-------:|:--------:|
+| owner       | The owner of the environment                                                                                |    string    |         |   Yes    |
+| namespace   | The unique namespace for the environment, which could be your organization name or abbreviation, e.g. 'odc' |    string    |         |   Yes    |
+| environment | The name of the environment - e.g. dev, stage                                                               |    string    |         |   Yes    |
+| attributes  | Additional attributes (e.g. `region`)                                                                       | list(string) |   []    |    No    |
+| delimiter   | Delimiter to be used between `namespace`, `stage`, `name` and `attributes`                                  |    string    |   "-"   |    No    |
+| tags        | Additional tags - e.g. `map('StackName','XYZ')`                                                             | map(string)  |   {}    |    No    |
+
+### Outputs
+| Name                    | Description                         | Sensitive |
+|-------------------------|-------------------------------------|-----------|
+| tf_state_bucket         | Terraform state store bucket        | false     |
+| tf_state_dynamodb_table | Terraform state lock dynamodb table | false     |

--- a/backend_init/output.tf
+++ b/backend_init/output.tf
@@ -1,0 +1,7 @@
+output "tf_state_bucket" {
+  value = aws_s3_bucket.terraform_state_storage_s3.*.id
+}
+
+output "tf_dynamodb_table" {
+  value = aws_dynamodb_table.terraform_state_lock.*.name
+}

--- a/backend_init/terraform_backend.tf
+++ b/backend_init/terraform_backend.tf
@@ -1,0 +1,75 @@
+module "backend_label" {
+  source     = "git::https://github.com/cloudposse/terraform-null-label.git?ref=tags/0.24.1"
+  namespace  = var.namespace
+  stage      = var.environment
+  name       = "backend"
+  attributes = var.attributes
+  delimiter  = var.delimiter
+
+  tags = merge(
+    {
+      owner       = var.owner
+      namespace   = var.namespace
+      environment = var.environment
+    },
+    var.tags
+  )
+}
+
+# create S3 bucket to store the state file in
+resource "aws_s3_bucket" "terraform_state_storage_s3" {
+  bucket = "${module.backend_label.id}-tfstate"
+
+  # Uncomment this to prevent unintended destruction of state
+  # lifecycle {
+  #   prevent_destroy = true
+  # }
+
+  tags = module.backend_label.tags
+}
+
+resource "aws_s3_bucket_acl" "terraform_state_storage_s3" {
+  bucket = aws_s3_bucket.terraform_state_storage_s3.id
+  acl    = "private"
+}
+
+resource "aws_s3_bucket_versioning" "terraform_state_storage_s3" {
+  bucket = aws_s3_bucket.terraform_state_storage_s3.id
+  versioning_configuration {
+    status = "Enabled"
+  }
+}
+
+resource "aws_s3_bucket_server_side_encryption_configuration" "terraform_state_storage_s3" {
+  bucket = aws_s3_bucket.terraform_state_storage_s3.bucket
+
+  rule {
+    apply_server_side_encryption_by_default {
+      sse_algorithm = "AES256"
+    }
+  }
+}
+
+resource "aws_s3_bucket_public_access_block" "terraform_state_storage_s3" {
+  bucket = aws_s3_bucket.terraform_state_storage_s3.id
+
+  block_public_acls       = true
+  block_public_policy     = true
+  ignore_public_acls      = true
+  restrict_public_buckets = true
+}
+
+# The terraform lock database resource
+resource "aws_dynamodb_table" "terraform_state_lock" {
+  name           = "${module.backend_label.id}-tflock"
+  read_capacity  = 5
+  write_capacity = 5
+  hash_key       = "LockID"
+
+  attribute {
+    name = "LockID"
+    type = "S"
+  }
+
+  tags = module.backend_label.tags
+}

--- a/backend_init/variables.tf
+++ b/backend_init/variables.tf
@@ -1,0 +1,32 @@
+variable "namespace" {
+  description = "The name used for creation of backend resources like the terraform state bucket"
+  default     = "dea-odc"
+}
+
+variable "owner" {
+  description = "The owner of the environment"
+  default     = "dea"
+}
+
+variable "environment" {
+  description = "The name of the environment - e.g. dev, stage, prod"
+  default     = "dev"
+}
+
+variable "delimiter" {
+  type        = string
+  default     = "-"
+  description = "Delimiter to be used between `namespace`, `stage`, `name` and `attributes`"
+}
+
+variable "attributes" {
+  type        = list(string)
+  default     = []
+  description = "Additional attributes (e.g. `region`)"
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Additional tags (e.g. `map('StackName','XYZ')`"
+  default     = {}
+}

--- a/eks/README.md
+++ b/eks/README.md
@@ -1,0 +1,139 @@
+# Terraform EKS Setup Module: eks
+
+Terraform module designed to provision an EKS cluster on AWS.
+
+---
+
+## Requirements
+
+[AWS CLI](https://aws.amazon.com/cli/)
+
+[Kubectl](https://kubernetes.io/docs/tasks/tools/install-kubectl/)
+
+[Helm](https://github.com/kubernetes/helm#install)
+
+[Terraform](https://www.terraform.io/downloads.html)
+
+[Fluxctl](https://docs.fluxcd.io/en/stable/tutorials/get-started.html) -(optional)
+
+## Introduction
+
+The module provisions the following resources:
+
+- Creates AWS EKS cluster in a VPC with subnets
+- (Optionally) Creates VPC resources using [terraform-aws-vpc](https://github.com/terraform-aws-modules/terraform-aws-vpc) module with the default configuration and internet facing resources, _or_
+- (Optionally) Use a supplied VPC and subnets configured and _tagged_ as required by AWS EKS - see [VPC considerations](https://docs.aws.amazon.com/eks/latest/userguide/network_reqs.html) and the requirements on subnet tagging for the [Application load balancing on Amazon EKS](https://docs.aws.amazon.com/eks/latest/userguide/alb-ingress.html)
+
+## Usage
+
+The complete terraform AWS example is provided for kick-start [here](https://github.com/ga-scr/dpas-terraform-modules/tree/master/examples).
+Copy the example to create your own live repo to set up EKS infrastructure to run dpas processing in your own AWS account.
+
+```terraform
+module "dpas_eks" {
+  source = "git@github.com:ga-scr/dpas-terraform-modules.git//eks?ref=main"
+
+  # Cluster config
+  cluster_id      = local.cluster_id
+  cluster_version = local.cluster_version
+
+  # Default Tags
+  owner       = local.owner
+  namespace   = local.namespace
+  environment = local.environment
+
+  # Additional Tags
+  tags = local.tags
+
+  # VPC and subnets config
+  create_vpc             = "true"
+  enable_vpc_s3_endpoint = "true"
+  vpc_cidr               = local.vpc_cidr
+  public_subnet_cidrs    = local.public_subnet_cidrs
+  private_subnet_cidrs   = local.private_subnet_cidrs
+  database_subnet_cidrs  = local.database_subnet_cidrs
+
+  # Default nodegroup config
+  # This ensures core services such as VPC CNI, CoreDNS, etc. are up and running
+  # so that Karpenter can be deployed and start managing compute capacity as required
+  default_worker_instance_type = local.default_worker_instance_type
+  min_nodes                    = 1
+  max_nodes                    = 2
+  extra_userdata               = local.extra_userdata
+  extra_bootstrap_args         = local.extra_bootstrap_args
+
+  cluster_addons = {
+    coredns = {
+      resolve_conflicts = "OVERWRITE"
+    }
+    kube-proxy = {
+      resolve_conflicts = "OVERWRITE"
+    }
+    vpc-cni = {
+      resolve_conflicts = "OVERWRITE"
+    }
+  }
+}
+```
+
+## Variables
+
+### Inputs
+| Name                                   | Description                                                                                                                                                                                            |     Type     |              Default              | Required |
+|----------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------------:|:---------------------------------:|:--------:|
+| owner                                  | The owner of the environment                                                                                                                                                                           |    string    |                                   |   yes    |
+| namespace                              | The unique namespace for the environment, which could be your organization name or abbreviation, e.g. 'odc'                                                                                            |    string    |                                   |   yes    |
+| environment                            | The name of the environment - e.g. dev, stage                                                                                                                                                          |    string    |                                   |   yes    |
+| cluster_id                             | The name of your cluster. Used for the resource naming as identifier                                                                                                                                   |    string    |                                   |   yes    |
+| cluster_version                        | EKS Cluster version to use                                                                                                                                                                             |    string    |                                   |   Yes    |
+| cluster_enabled_log_types              | A list of the desired control plane logs to enable. See Amazon EKS Control Plane Logging documentation for more information - https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html | list(string) | ["audit", "api", "authenticator"] |    No    |
+| create_cluster_cloudwatch_log_group    | Determines whether a log group is created by this module for the cluster logs. If not, AWS will automatically create one if logging is enabled                                                         |     bool     |               true                |    No    |
+| cloudwatch_log_group_retention_in_days | Number of days to retain log events. Default retention - 30 days                                                                                                                                       |    number    |                30                 |    No    |
+| cloudwatch_log_group_kms_key_id        | If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group                                                                                                                  |    string    |               null                |    No    |
+| cluster_addons                         | Map of cluster addon configurations to enable for the cluster. Addon name can be the map keys or set with `name`                                                                                       | map(string)  |                {}                 |    No    |
+| create_vpc                             | Determines whether to create the VPC and subnets or to supply them. If supplied then subnets and tagging must be configured correctly for AWS EKS use - see AWS EKS VPC requirements documentation     |     bool     |               false               |    No    |
+| enable_vpc_s3_endpoint                 | Determines whether to provision an S3 gateway endpoint to the VPC. Default is set to 'true'                                                                                                            |     bool     |               false               |    No    |
+| vpc_id                                 | ID of the VPC to place EKS in. Use if create_vpc=false                                                                                                                                                 |    string    |                                   |    No    |
+| private_subnets                        | List of private subnets to use if create_vpc = false                                                                                                                                                   |    string    |                []                 |    No    |
+| vpc_cidr                               | The network CIDR you wish to use for the VPC module subnets. Default is set to 10.0.0.0/16 for most use-cases. Requires create_vpc = true                                                              |    string    |           "10.0.0.0/16"           |    No    |
+| public_subnet_cidrs                    | List of public cidrs, for all available availability zones. Used by VPC module to set up public subnets. Requires create_vpc = true                                                                    | list(string) |                []                 |    No    |
+| private_subnet_cidrs                   | List of private cidrs, for all available availability zones. Used by VPC module to set up private subnets. Requires create_vpc = true                                                                  | list(string) |                []                 |    No    |
+| database_subnet_cidrs                  | List of database cidrs, for all available availability zones. Used by VPC module to set up database subnets. Requires create_vpc = true                                                                | list(string) |                []                 |    No    |
+| admin_access_CIDRs                     | Locks ssh and api access to these IPs                                                                                                                                                                  | map(string)  |                {}                 |    No    |
+| ami_image_id                           | This variable can be used to deploy a patched / customised version of the Amazon EKS image                                                                                                             |    string    |                ""                 |    No    |
+| default_worker_instance_type           | The default nodegroup worker instance type that the cluster nodes core components will run                                                                                                             |    string    |            m6g.medium             |    No    |
+| min_nodes                              | The minimum number of on-demand nodes to run                                                                                                                                                           |    number    |                 0                 |    No    |
+| desired_nodes                          | Desired number of nodes only used when first launching the cluster afterwards you should scale with something like cluster-autoscaler                                                                  |    number    |                 0                 |    No    |
+| max_nodes                              | Max number of nodes you want to run, useful for controlling max cost of the cluster                                                                                                                    |    number    |                 0                 |    No    |
+| root_block_device_mappings             | Specify root EBS volume properties                                                                                                                                                                     |     any      |      <see variables.tf file>      |    No    |
+| additional_block_device_mappings       | Specify volumes to attach to the instance besides the volumes specified by the AMI                                                                                                                     |     any      |      <see variables.tf file>      |    No    |
+| extra_userdata                         | Additional EC2 user data commands that will be passed to EKS nodes                                                                                                                                     |    string    |      <see variables.tf file>      |    No    |
+| extra_kubelet_args                     | Additional kubelet command-line arguments                                                                                                                                                              |    string    |                ""                 |    No    |
+| extra_bootstrap_args                   | Additional bootstrap command-line arguments                                                                                                                                                            |    string    |                ""                 |    No    |
+| extra_node_labels                      | Additional node labels e.g. 'label1=value1,label2=value2'                                                                                                                                              |    string    |                ""                 |    No    |
+| tags                                   | Additional tags - e.g. `map('StackName','XYZ')`                                                                                                                                                        | map(string)  |                {}                 |    No    |
+| extra_node_tags                        | Additional tags for EKS nodes (e.g. `map('StackName','XYZ')`                                                                                                                                           | map(string)  |                {}                 |    No    |
+| aws_auth_roles                         | List of role maps to add to the aws-auth configmap                                                                                                                                                     | map(string)  |                []                 |    No    |
+| aws_auth_users                         | List of user maps to add to the aws-auth configmap                                                                                                                                                     | map(string)  |                []                 |    No    |
+| aws_auth_accounts                      | List of account maps to add to the aws-auth configmap                                                                                                                                                  | map(string)  |                []                 |    No    |
+| enable_irsa                            | Determines whether to create an OpenID Connect Provider for EKS to enable IRSA                                                                                                                         |     bool     |               true                |    No    |
+| openid_connect_audiences               | List of OpenID Connect audience client IDs to add to the IRSA provider                                                                                                                                 | list(string) |                []                 |    No    |
+| custom_oidc_thumbprints                | Additional list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s)                                                                              | list(string) |                []                 |    No    |
+
+### Outputs
+| Name                   | Description                                             | Sensitive |
+|------------------------|---------------------------------------------------------|-----------|
+| cluster_id             | EKS cluster ID                                          | false     |
+| cluster_version        | EKS cluster version                                     | false     |
+| ami_image_id           | AMI ID used for worker EC2 instance node group          | false     |
+| node_instance_profile  | EC2 instance profile for EKS work node group            | false     |
+| node_security_group    | security group for EKS work node group                  | false     |
+| node_role_arn          | IAM role ARN for EKS work node group                    | false     |
+| node_role_name         | IAM role name for EKS work node group                   | false     |
+| node_asg_name          | EKS work node group name                                | false     |
+| oidc_arn               | EKS cluster OpenID Connect (OIDC) identity provider ARN | false     |
+| oidc_url               | EKS cluster OpenID Connect (OIDC) identity provider URL | false     |
+| vpc_id                 | EKS cluster VPC ID                                      | false     |
+| database_subnets       | List of database subnets                                | false     |
+| private_subnets        | List of private subnets                                 | false     |
+| public_route_table_ids | Public subnet route table ids                           | false     |

--- a/eks/aws_auth.tf
+++ b/eks/aws_auth.tf
@@ -1,0 +1,26 @@
+locals {
+  aws_auth_configmap_data = {
+    mapRoles = yamlencode(concat(
+      [{
+        rolearn  = aws_iam_role.eks_node.arn
+        username = "system:node:{{EC2PrivateDNSName}}"
+        groups = [
+          "system:bootstrappers",
+          "system:nodes",
+        ]
+      }],
+      var.aws_auth_roles
+    ))
+    mapUsers    = length(var.aws_auth_users) == 0 ? null : yamlencode(var.aws_auth_users)
+    mapAccounts = length(var.aws_auth_accounts) == 0 ? null : yamlencode(var.aws_auth_accounts)
+  }
+}
+resource "kubernetes_config_map" "aws_auth" {
+  metadata {
+    name      = "aws-auth"
+    namespace = "kube-system"
+  }
+
+  data = local.aws_auth_configmap_data
+}
+

--- a/eks/data_providers.tf
+++ b/eks/data_providers.tf
@@ -1,0 +1,12 @@
+data "aws_partition" "current" {}
+data "aws_availability_zones" "available" {}
+data "aws_caller_identity" "current" {}
+data "aws_canonical_user_id" "current" {}
+data "aws_region" "current" {}
+
+locals {
+  vpc_id              = var.create_vpc ? module.vpc[0].vpc_id : var.vpc_id
+  vpc_private_subnets = var.create_vpc ? module.vpc[0].private_subnets : var.private_subnets
+
+  dns_suffix = data.aws_partition.current.dns_suffix
+}

--- a/eks/irsa.tf
+++ b/eks/irsa.tf
@@ -1,0 +1,23 @@
+data "tls_certificate" "this" {
+  count = var.enable_irsa ? 1 : 0
+
+  url = aws_eks_cluster.eks.identity[0].oidc[0].issuer
+}
+
+resource "aws_iam_openid_connect_provider" "oidc_provider" {
+  count = var.enable_irsa ? 1 : 0
+
+  client_id_list  = concat(["sts.${local.dns_suffix}"], var.openid_connect_audiences)
+  thumbprint_list = concat([data.tls_certificate.this[0].certificates[0].sha1_fingerprint], var.custom_oidc_thumbprints)
+  url             = aws_eks_cluster.eks.identity[0].oidc[0].issuer
+
+  tags = merge(
+    {
+      Name        = "${var.cluster_id}-eks-irsa"
+      owner       = var.owner
+      namespace   = var.namespace
+      environment = var.environment
+    },
+    var.tags
+  )
+}

--- a/eks/lb_sg.tf
+++ b/eks/lb_sg.tf
@@ -1,0 +1,36 @@
+resource "aws_security_group" "eks_lb" {
+  name        = "${var.cluster_id}-lb-sg"
+  description = "Security group for eks load balancers"
+  vpc_id      = local.vpc_id
+
+  ingress {
+    from_port   = 443
+    to_port     = 443
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  ingress {
+    from_port   = 80
+    to_port     = 80
+    protocol    = "tcp"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    {
+      Name        = "${var.cluster_id}-lb-sg"
+      owner       = var.owner
+      namespace   = var.namespace
+      environment = var.environment
+    },
+    var.tags
+  )
+}

--- a/eks/master_addons.tf
+++ b/eks/master_addons.tf
@@ -1,0 +1,25 @@
+resource "aws_eks_addon" "eks_addons" {
+  for_each = { for k, v in var.cluster_addons : k => v }
+
+  cluster_name = aws_eks_cluster.eks.name
+  addon_name   = try(each.value.name, each.key)
+
+  addon_version            = lookup(each.value, "addon_version", null)
+  resolve_conflicts        = lookup(each.value, "resolve_conflicts", null)
+  service_account_role_arn = lookup(each.value, "service_account_role_arn", null)
+
+  depends_on = [
+    aws_autoscaling_group.node,
+    kubernetes_config_map.aws_auth
+  ]
+
+  tags = merge(
+    {
+      Name        = var.cluster_id
+      owner       = var.owner
+      namespace   = var.namespace
+      environment = var.environment
+    },
+    var.tags
+  )
+}

--- a/eks/master_cloudwatch_loggroup.tf
+++ b/eks/master_cloudwatch_loggroup.tf
@@ -1,0 +1,16 @@
+resource "aws_cloudwatch_log_group" "eks_cluster" {
+  count = var.create_cluster_cloudwatch_log_group ? 1 : 0
+
+  name              = "/aws/eks/${var.cluster_id}/cluster"
+  retention_in_days = var.cloudwatch_log_group_retention_in_days
+  kms_key_id        = var.cloudwatch_log_group_kms_key_id
+
+  tags = merge(
+    {
+      owner       = var.owner
+      namespace   = var.namespace
+      environment = var.environment
+    },
+    var.tags
+  )
+}

--- a/eks/master_plane.tf
+++ b/eks/master_plane.tf
@@ -1,0 +1,43 @@
+resource "aws_eks_cluster" "eks" {
+  name                      = var.cluster_id
+  role_arn                  = aws_iam_role.eks_cluster.arn
+  version                   = var.cluster_version
+  enabled_cluster_log_types = var.cluster_enabled_log_types
+
+  vpc_config {
+    security_group_ids = [aws_security_group.eks_cluster.id]
+    subnet_ids         = var.create_vpc ? module.vpc[0].private_subnets : var.private_subnets
+  }
+
+  depends_on = [
+    aws_iam_role_policy_attachment.eks-cluster-AmazonEKSClusterPolicy,
+    aws_iam_role_policy_attachment.eks-cluster-AmazonEKSServicePolicy,
+    aws_cloudwatch_log_group.eks_cluster
+  ]
+
+  tags = merge(
+    {
+      Name        = var.cluster_id
+      owner       = var.owner
+      namespace   = var.namespace
+      environment = var.environment
+    },
+    var.tags
+  )
+}
+
+# wait for eks cluster to be healthy
+resource "null_resource" "wait_for_cluster" {
+
+  depends_on = [
+    aws_eks_cluster.eks,
+  ]
+
+  provisioner "local-exec" {
+    interpreter = ["/bin/sh", "-c"]
+    command     = "for i in `seq 1 60`; do if `command -v wget > /dev/null`; then wget --no-check-certificate -O - -q $ENDPOINT/healthz >/dev/null && exit 0 || true; else curl -k -s $ENDPOINT/healthz >/dev/null && exit 0 || true;fi; sleep 5; done; echo TIMEOUT && exit 1"
+    environment = {
+      ENDPOINT = aws_eks_cluster.eks.endpoint
+    }
+  }
+}

--- a/eks/master_policy.tf
+++ b/eks/master_policy.tf
@@ -1,0 +1,53 @@
+resource "aws_iam_role" "eks_cluster" {
+  name = "${var.cluster_id}-cluster-role"
+
+  assume_role_policy = <<-POLICY
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "eks.${local.dns_suffix}"
+          },
+          "Action": "sts:AssumeRole"
+        }
+      ]
+    }
+  POLICY
+
+  # https://github.com/terraform-aws-modules/terraform-aws-eks/issues/920
+  # Resources running on the cluster are still generating logs when destroying the module resources
+  # which results in the log group being re-created even after Terraform destroys it. Removing the
+  # ability for the cluster role to create the log group prevents this log group from being re-created
+  # outside of Terraform due to services still generating logs during destroy process
+  dynamic "inline_policy" {
+    for_each = var.create_cluster_cloudwatch_log_group ? [1] : []
+    content {
+      name = "${var.cluster_id}-cluster-policy"
+
+      policy = jsonencode({
+        Version = "2012-10-17"
+        Statement = [
+          {
+            Action   = ["logs:CreateLogGroup"]
+            Effect   = "Deny"
+            Resource = "*"
+          },
+        ]
+      })
+    }
+  }
+
+}
+
+resource "aws_iam_role_policy_attachment" "eks-cluster-AmazonEKSClusterPolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSClusterPolicy"
+  role       = aws_iam_role.eks_cluster.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks-cluster-AmazonEKSServicePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSServicePolicy"
+  role       = aws_iam_role.eks_cluster.name
+}
+

--- a/eks/master_sg.tf
+++ b/eks/master_sg.tf
@@ -1,0 +1,54 @@
+resource "aws_security_group" "eks_cluster" {
+  name        = "${var.cluster_id}-cluster-sg"
+  description = "Cluster communication with worker nodes"
+  vpc_id      = local.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  tags = merge(
+    {
+      Name        = "${var.cluster_id}-cluster-sg"
+      owner       = var.owner
+      namespace   = var.namespace
+      environment = var.environment
+    },
+    var.tags
+  )
+}
+
+# TODO: review security group rules configuration as per EKS document
+resource "aws_security_group_rule" "eks_cluster_ingress_node_https" {
+  description              = "Allow worker nodes to communicate with control pane over https"
+  type                     = "ingress"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_cluster.id
+  source_security_group_id = aws_security_group.eks_node.id
+}
+
+# Converts admin_access_CIDRs to descriptions / IP CIDRs
+resource "aws_security_group_rule" "eks_cluster_ingress_workstation_https" {
+  count             = length(var.admin_access_CIDRs)
+  description       = element(keys(var.admin_access_CIDRs), count.index)
+  type              = "ingress"
+  from_port         = 443
+  to_port           = 443
+  protocol          = "tcp"
+  security_group_id = aws_security_group.eks_cluster.id
+  cidr_blocks       = [element(values(var.admin_access_CIDRs), count.index)]
+}
+
+# Security group - outbound
+# Refernce: https://docs.aws.amazon.com/eks/latest/userguide/sec-group-reqs.html
+resource "aws_security_group_rule" "eks_cluster_egress_node" {
+  description              = "Allow cluster control pane to communicate with worker nodes"
+  type                     = "egress"
+  from_port                = 1025
+  to_port                  = 65535
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_cluster.id
+  source_security_group_id = aws_security_group.eks_node.id
+}

--- a/eks/outputs.tf
+++ b/eks/outputs.tf
@@ -1,0 +1,61 @@
+output "cluster_id" {
+  value = aws_eks_cluster.eks.id
+  # So that calling plans wait for the cluster to be available before attempting to use it
+  depends_on = [null_resource.wait_for_cluster]
+}
+
+output "cluster_version" {
+  value = aws_eks_cluster.eks.version
+}
+
+output "ami_image_id" {
+  value = local.ami_id
+}
+
+output "node_instance_profile" {
+  value = aws_iam_instance_profile.eks_node.id
+}
+
+output "node_security_group" {
+  value = aws_security_group.eks_node.id
+}
+
+output "api_endpoint" {
+  value = aws_eks_cluster.eks.endpoint
+}
+
+output "node_role_arn" {
+  value = aws_iam_role.eks_node.arn
+}
+
+output "node_role_name" {
+  value = aws_iam_role.eks_node.name
+}
+
+output "node_asg_name" {
+  value = aws_autoscaling_group.node.name
+}
+
+output "oidc_arn" {
+  value = var.enable_irsa ? aws_iam_openid_connect_provider.oidc_provider.0.arn : null
+}
+
+output "oidc_url" {
+  value = var.enable_irsa ? aws_iam_openid_connect_provider.oidc_provider.0.url : null
+}
+
+output "vpc_id" {
+  value = local.vpc_id
+}
+
+output "database_subnets" {
+  value = var.create_vpc ? module.vpc[0].database_subnets : []
+}
+
+output "private_subnets" {
+  value = var.create_vpc ? module.vpc[0].private_subnets : []
+}
+
+output "public_route_table_ids" {
+  value = var.create_vpc ? module.vpc[0].public_route_table_ids : []
+}

--- a/eks/variables.tf
+++ b/eks/variables.tf
@@ -1,0 +1,268 @@
+variable "cluster_id" {
+  default = "The name of your cluster. Used for the resource naming as identifier"
+  type    = string
+}
+
+variable "cluster_version" {
+  description = "EKS Version to use with this cluster"
+  type        = string
+}
+
+variable "cluster_enabled_log_types" {
+  description = "A list of the desired control plane logs to enable. For more information, see Amazon EKS Control Plane Logging documentation (https://docs.aws.amazon.com/eks/latest/userguide/control-plane-logs.html)"
+  type        = list(string)
+  default     = ["audit", "api", "authenticator"]
+}
+
+#--------------------------------------------------------------
+# CloudWatch Log Group
+#--------------------------------------------------------------
+variable "create_cluster_cloudwatch_log_group" {
+  description = "Determines whether a log group is created by this module for the cluster logs. If not, AWS will automatically create one if logging is enabled"
+  type        = bool
+  default     = true
+}
+
+variable "cloudwatch_log_group_retention_in_days" {
+  description = "Number of days to retain log events. Default retention - 30 days"
+  type        = number
+  default     = 30
+}
+
+variable "cloudwatch_log_group_kms_key_id" {
+  description = "If a KMS Key ARN is set, this key will be used to encrypt the corresponding log group. Please be sure that the KMS Key has an appropriate key policy (https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/encrypt-log-data-kms.html)"
+  type        = string
+  default     = null
+}
+
+#--------------------------------------------------------------
+# EKS Addons
+#--------------------------------------------------------------
+
+variable "cluster_addons" {
+  description = "Map of cluster addon configurations to enable for the cluster. Addon name can be the map keys or set with `name`"
+  type        = any
+  default     = {}
+}
+
+#--------------------------------------------------------------
+# VPC and Subnets
+#--------------------------------------------------------------
+variable "create_vpc" {
+  type        = bool
+  description = "Determines whether to create the VPC and subnets or to supply them. If supplied then subnets and tagging must be configured correctly for AWS EKS use - see AWS EKS VPC requirments documentation"
+  default     = true
+}
+
+## Create VPC = false
+variable "vpc_id" {
+  type        = string
+  description = "ID of the VPC to place EKS in. Use if 'create_vpc = false'"
+  default     = ""
+}
+
+variable "private_subnets" {
+  type        = list(string)
+  description = "List of private subnets to use if 'create_vpc = false'"
+  default     = []
+}
+
+## Create VPC = true
+variable "vpc_cidr" {
+  type        = string
+  description = "The network CIDR you wish to use for the VPC module subnets. Default is set to 10.0.0.0/16 for most use-cases. Requires 'create_vpc = true'"
+  default     = "10.0.0.0/16"
+}
+
+variable "public_subnet_cidrs" {
+  description = "List of public cidrs, for all available availability zones. Used by VPC module to set up public subnets. Requires 'create_vpc = true'. Example: ['10.0.0.0/22', '10.0.4.0/22', '10.0.8.0/22']"
+  type        = list(string)
+  default     = []
+}
+
+variable "private_subnet_cidrs" {
+  description = "List of private cidrs, for all available availability zones. Used by VPC module to set up private subnets. Requires 'create_vpc = true'. Example: ['10.0.32.0/19', 10.0.64.0/19', '10.0.96.0/19']"
+  type        = list(string)
+  default     = []
+}
+
+variable "database_subnet_cidrs" {
+  description = "List of database cidrs, for all available availability zones. Used by VPC module to set up database subnets. Requires 'create_vpc = true'. Example: ['10.0.20.0/22', '10.0.24.0/22', '10.0.28.0/22']"
+  type        = list(string)
+  default     = []
+}
+
+variable "enable_vpc_s3_endpoint" {
+  type        = bool
+  description = "Determines whether to provision an S3 endpoint to the VPC. Default is set to 'true'"
+  default     = false
+}
+
+variable "admin_access_CIDRs" {
+  description = "Locks ssh and api access to these IPs"
+  type        = map(string)
+  default     = {}
+}
+
+#--------------------------------------------------------------
+# Worker variables
+#--------------------------------------------------------------
+variable "ami_image_id" {
+  description = "Overwrites the default ami (latest Amazon EKS)"
+  type        = string
+  default     = ""
+}
+
+variable "default_worker_instance_type" {
+  description = "The default nodegroup worker instance type that the cluster nodes core components will run"
+  type        = string
+  default     = "t3.medium"
+}
+
+variable "min_nodes" {
+  description = "The minimum number of on-demand nodes to run"
+  type        = number
+  default     = 0
+}
+
+variable "desired_nodes" {
+  description = "Desired number of nodes only used when first launching the cluster"
+  type        = number
+  default     = 0
+}
+
+variable "max_nodes" {
+  description = "Max number of nodes you want to run"
+  type        = number
+  default     = 0
+}
+
+variable "root_block_device_mappings" {
+  description = "Specify root EBS volume properties"
+  type        = any
+  default = {
+    device_name = "/dev/xvda"
+    ebs = {
+      volume_size           = 20
+      volume_type           = "gp3"
+      iops                  = 3000
+      throughput            = 150
+      encrypted             = true
+      delete_on_termination = true
+    }
+  }
+}
+
+variable "additional_block_device_mappings" {
+  description = "Specify volumes to attach to the instance besides the volumes specified by the AMI"
+  type        = any
+  default     = {}
+  # Example:
+  # additional_block_device_mappings = {
+  #   sda1 = {
+  #     device_name = "/dev/sda1"
+  #     ebs = {
+  #       volume_size           = 20
+  #       volume_type           = "gp3"
+  #       iops                  = 3000
+  #       throughput            = 150
+  #       encrypted             = true
+  #       kms_key_id            = aws_kms_key.ebs.arn
+  #       delete_on_termination = true
+  #     }
+  #   }
+  # }
+}
+
+variable "extra_userdata" {
+  type        = string
+  description = "Additional EC2 user data commands that will be passed to EKS nodes"
+  default     = <<-USERDATA
+  echo ""
+  USERDATA
+}
+
+variable "extra_kubelet_args" {
+  type        = string
+  description = "Additional kubelet command-line arguments (e.g. '--arg1=value --arg2')"
+  default     = ""
+}
+
+variable "extra_bootstrap_args" {
+  type        = string
+  description = "Additional bootstrap.sh command-line arguments (e.g. '--arg1=value --arg2')"
+  default     = ""
+}
+
+variable "extra_node_labels" {
+  type        = string
+  description = "Additional node labels e.g. 'label1=value1,label2=value2'"
+  default     = ""
+}
+
+#--------------------------------------------------------------
+# Tags
+#--------------------------------------------------------------
+variable "environment" {
+}
+
+variable "namespace" {
+}
+
+variable "owner" {
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Additional tags (e.g. `map('StackName','XYZ')`"
+  default     = {}
+}
+
+variable "extra_node_tags" {
+  type        = map(string)
+  description = "Additional tags for EKS nodes (e.g. `map('StackName','XYZ')`"
+  default     = {}
+}
+
+#--------------------------------------------------------------
+# aws-auth configmap
+#--------------------------------------------------------------
+variable "aws_auth_roles" {
+  description = "List of role maps to add to the aws-auth configmap"
+  type        = list(any)
+  default     = []
+}
+
+variable "aws_auth_users" {
+  description = "List of user maps to add to the aws-auth configmap"
+  type        = list(any)
+  default     = []
+}
+
+variable "aws_auth_accounts" {
+  description = "List of account maps to add to the aws-auth configmap"
+  type        = list(any)
+  default     = []
+}
+
+#--------------------------------------------------------------
+# IRSA
+#--------------------------------------------------------------
+variable "enable_irsa" {
+  description = "Determines whether to create an OpenID Connect Provider for EKS to enable IRSA"
+  type        = bool
+  default     = true
+}
+
+variable "openid_connect_audiences" {
+  description = "List of OpenID Connect audience client IDs to add to the IRSA provider"
+  type        = list(string)
+  default     = []
+}
+
+variable "custom_oidc_thumbprints" {
+  description = "Additional list of server certificate thumbprints for the OpenID Connect (OIDC) identity provider's server certificate(s)"
+  type        = list(string)
+  default     = []
+}
+

--- a/eks/vpc.tf
+++ b/eks/vpc.tf
@@ -1,0 +1,81 @@
+# VPC Module
+##############################
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "v3.14.2"
+
+  count = var.create_vpc ? 1 : 0
+
+  name             = "${var.cluster_id}-vpc"
+  cidr             = var.vpc_cidr
+  azs              = data.aws_availability_zones.available.names
+  public_subnets   = var.public_subnet_cidrs
+  private_subnets  = var.private_subnet_cidrs
+  database_subnets = var.database_subnet_cidrs
+
+  private_subnet_tags = {
+    "SubnetType"                              = "Private"
+    "kubernetes.io/cluster/${var.cluster_id}" = "shared"
+    "kubernetes.io/role/internal-elb"         = "1"
+  }
+
+  public_subnet_tags = {
+    "SubnetType"                              = "Utility"
+    "kubernetes.io/cluster/${var.cluster_id}" = "shared"
+    "kubernetes.io/role/elb"                  = "1"
+  }
+
+  database_subnet_tags = {
+    "SubnetType" = "Database"
+  }
+
+  enable_dns_hostnames = true
+  enable_dns_support   = true
+
+  enable_nat_gateway           = true
+  create_database_subnet_group = true
+
+  tags = merge(
+    {
+      Name        = "${var.cluster_id}-vpc"
+      owner       = var.owner
+      namespace   = var.namespace
+      environment = var.environment
+    },
+    var.tags
+  )
+}
+
+# VPC Endpoints Module
+########################################
+module "s3_endpoint" {
+  source = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+
+  create = var.create_vpc && var.enable_vpc_s3_endpoint
+
+  vpc_id             = local.vpc_id
+  security_group_ids = []
+
+  endpoints = {
+    s3 = {
+      service      = "s3"
+      service_type = "Gateway"
+      route_table_ids = flatten([
+        module.vpc[0].private_route_table_ids,
+        module.vpc[0].public_route_table_ids,
+      ])
+      tags = {
+        Name = "${var.cluster_id}-s3-vpc-endpoint"
+      }
+    },
+  }
+
+  tags = merge(
+    {
+      owner       = var.owner
+      namespace   = var.namespace
+      environment = var.environment
+    },
+    var.tags
+  )
+}

--- a/eks/worker_asg.tf
+++ b/eks/worker_asg.tf
@@ -1,0 +1,44 @@
+resource "aws_autoscaling_group" "node" {
+  desired_capacity    = var.desired_nodes
+  max_size            = var.max_nodes
+  min_size            = var.min_nodes
+  name                = "${var.cluster_id}-${aws_launch_template.node.id}-node"
+  vpc_zone_identifier = local.vpc_private_subnets
+
+  # Don't reset to default size every time terraform is applied
+  lifecycle {
+    ignore_changes        = [desired_capacity]
+    create_before_destroy = true
+  }
+
+  launch_template {
+    id      = aws_launch_template.node.id
+    version = aws_launch_template.node.latest_version
+  }
+
+  # Use a dynamic tag block rather than tags = [<list of tags>] to workaround this issue https://github.com/hashicorp/terraform-provider-aws/issues/14085
+  dynamic "tag" {
+    for_each = merge(
+      {
+        Name        = "${var.cluster_id}-${aws_launch_template.node.id}-node"
+        environment = var.environment
+        namespace   = var.namespace
+        owner       = var.owner
+
+        "kubernetes.io/cluster/${aws_eks_cluster.eks.id}" = "owned"
+      },
+      var.tags,
+      var.extra_node_tags
+    )
+    content {
+      key                 = tag.key
+      value               = tag.value
+      propagate_at_launch = true
+    }
+  }
+
+  # Don't break cluster autoscaler
+  suspended_processes = ["AZRebalance"]
+
+  depends_on = [aws_launch_template.node]
+}

--- a/eks/worker_lt.tf
+++ b/eks/worker_lt.tf
@@ -1,0 +1,96 @@
+data "aws_ami" "eks_worker" {
+  filter {
+    name   = "name"
+    values = ["amazon-eks-node-${aws_eks_cluster.eks.version}-v*"]
+  }
+
+  most_recent = true
+  owners      = ["602401143452"] # Amazon EKS AMI Account ID
+}
+
+locals {
+  # return first non-empty value
+  ami_id = coalesce(var.ami_image_id, data.aws_ami.eks_worker.id)
+}
+
+# EKS currently documents this required userdata for EKS worker nodes to
+# properly configure Kubernetes applications on the EC2 instance.
+# We utilize a Terraform locals here to simplify Base64 encoding this
+# information into the AutoScaling Launch Template.
+# More information: https://docs.aws.amazon.com/eks/latest/userguide/launch-workers.html
+data "template_file" "node_userdata" {
+  template = file("${path.module}/worker_userdata.tpl.sh")
+  vars = {
+    cluster_id            = aws_eks_cluster.eks.id
+    endpoint              = aws_eks_cluster.eks.endpoint
+    certificate_authority = aws_eks_cluster.eks.certificate_authority.0.data
+
+    extra_userdata       = var.extra_userdata
+    extra_kubelet_args   = var.extra_kubelet_args
+    extra_bootstrap_args = var.extra_bootstrap_args
+    extra_node_labels    = var.extra_node_labels
+  }
+}
+
+resource "aws_launch_template" "node" {
+  name_prefix   = "${var.cluster_id}-node-"
+  image_id      = local.ami_id
+  user_data     = base64encode(data.template_file.node_userdata.rendered)
+  instance_type = var.default_worker_instance_type
+
+  iam_instance_profile {
+    name = aws_iam_instance_profile.eks_node.id
+  }
+
+  network_interfaces {
+    associate_public_ip_address = false
+    security_groups             = [aws_security_group.eks_node.id]
+    delete_on_termination       = true
+  }
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  # root volume
+  block_device_mappings {
+    device_name = try(var.root_block_device_mappings.device_name, null)
+    ebs {
+      delete_on_termination = try(var.root_block_device_mappings.ebs.delete_on_termination, null)
+      encrypted             = try(var.root_block_device_mappings.ebs.encrypted, null)
+      iops                  = try(var.root_block_device_mappings.ebs.iops, null)
+      kms_key_id            = try(var.root_block_device_mappings.ebs.kms_key_id, null)
+      snapshot_id           = try(var.root_block_device_mappings.ebs.snapshot_id, null)
+      throughput            = try(var.root_block_device_mappings.ebs.throughput, null)
+      volume_size           = try(var.root_block_device_mappings.ebs.volume_size, null)
+      volume_type           = try(var.root_block_device_mappings.ebs.volume_type, null)
+    }
+  }
+
+  dynamic "block_device_mappings" {
+    for_each = var.additional_block_device_mappings
+
+    content {
+      device_name = try(block_device_mappings.value.device_name, null)
+
+      dynamic "ebs" {
+        for_each = try([block_device_mappings.value.ebs], [])
+
+        content {
+          delete_on_termination = try(ebs.value.delete_on_termination, null)
+          encrypted             = try(ebs.value.encrypted, null)
+          iops                  = try(ebs.value.iops, null)
+          kms_key_id            = try(ebs.value.kms_key_id, null)
+          snapshot_id           = try(ebs.value.snapshot_id, null)
+          throughput            = try(ebs.value.throughput, null)
+          volume_size           = try(ebs.value.volume_size, null)
+          volume_type           = try(ebs.value.volume_type, null)
+        }
+      }
+
+      no_device    = try(block_device_mappings.value.no_device, null)
+      virtual_name = try(block_device_mappings.value.virtual_name, null)
+    }
+  }
+}
+

--- a/eks/worker_policy.tf
+++ b/eks/worker_policy.tf
@@ -1,0 +1,54 @@
+resource "aws_iam_role" "eks_node" {
+  name = "nodes.${var.cluster_id}"
+
+  assume_role_policy = <<-POLICY
+    {
+      "Version": "2012-10-17",
+      "Statement": [
+        {
+          "Effect": "Allow",
+          "Principal": {
+            "Service": "ec2.${local.dns_suffix}"
+          },
+          "Action": "sts:AssumeRole"
+        }
+      ]
+    }
+  POLICY
+
+  tags = merge(
+    {
+      Name        = "nodes.${var.cluster_id}"
+      owner       = var.owner
+      namespace   = var.namespace
+      environment = var.environment
+    },
+    var.tags
+  )
+}
+
+resource "aws_iam_role_policy_attachment" "eks_node_AmazonEKSWorkerNodePolicy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+  role       = aws_iam_role.eks_node.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks_node_AmazonEKS_CNI_Policy" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+  role       = aws_iam_role.eks_node.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks_node_AmazonEC2ContainerRegistryReadOnly" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+  role       = aws_iam_role.eks_node.name
+}
+
+resource "aws_iam_role_policy_attachment" "eks_node_AmazonEC2RoleforSSM" {
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+  role       = aws_iam_role.eks_node.name
+}
+
+resource "aws_iam_instance_profile" "eks_node" {
+  name = "${var.cluster_id}-node"
+  role = aws_iam_role.eks_node.name
+}
+

--- a/eks/worker_sg.tf
+++ b/eks/worker_sg.tf
@@ -1,0 +1,80 @@
+resource "aws_security_group" "eks_node" {
+  name        = "${var.cluster_id}-node-sg"
+  description = "Security group for all nodes in the cluster"
+  vpc_id      = local.vpc_id
+
+  lifecycle {
+    create_before_destroy = true
+  }
+
+  egress {
+    from_port   = 0
+    to_port     = 0
+    protocol    = "-1"
+    cidr_blocks = ["0.0.0.0/0"]
+  }
+
+  tags = merge(
+    {
+      Name                                      = "${var.cluster_id}-node-sg"
+      owner                                     = var.owner
+      namespace                                 = var.namespace
+      environment                               = var.environment
+      "kubernetes.io/cluster/${var.cluster_id}" = "owned"
+    },
+    var.tags
+  )
+}
+
+# TODO: review security group rules configuration as per EKS document
+resource "aws_security_group_rule" "eks_node_ingress_self" {
+  description              = "Allow worker nodes to communicate with each other"
+  from_port                = 0
+  to_port                  = 65535
+  protocol                 = "-1"
+  security_group_id        = aws_security_group.eks_node.id
+  source_security_group_id = aws_security_group.eks_node.id
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "eks_node_ingress_cluster" {
+  description              = "Allow worker Kubelets and pods to receive communication from the cluster control plane"
+  from_port                = 1025
+  to_port                  = 65535
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_node.id
+  source_security_group_id = aws_security_group.eks_cluster.id
+  type                     = "ingress"
+}
+
+# for api metrics
+resource "aws_security_group_rule" "eks_node_ingress_cluster_https" {
+  description              = "Allow pods to communicate with the cluster API Server"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_node.id
+  source_security_group_id = aws_security_group.eks_cluster.id
+  type                     = "ingress"
+}
+
+# Connects workers to load balancers
+resource "aws_security_group_rule" "eks_node_ingress_lb_http" {
+  description              = "Allow worker pods to receive communication from the load balancers over http"
+  from_port                = 80
+  to_port                  = 80
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_node.id
+  source_security_group_id = aws_security_group.eks_lb.id
+  type                     = "ingress"
+}
+
+resource "aws_security_group_rule" "eks_node_ingress_lb_https" {
+  description              = "Allow worker pods to receive communication from the load balancers over https"
+  from_port                = 443
+  to_port                  = 443
+  protocol                 = "tcp"
+  security_group_id        = aws_security_group.eks_node.id
+  source_security_group_id = aws_security_group.eks_lb.id
+  type                     = "ingress"
+}

--- a/eks/worker_userdata.tpl.sh
+++ b/eks/worker_userdata.tpl.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+set -o xtrace
+# Get instance and ami id from the aws ec2 metadate endpoint
+id=$(curl http://169.254.169.254/latest/meta-data/instance-id -s)
+ami=$(curl http://169.254.169.254/latest/meta-data/ami-id -s)
+/etc/eks/bootstrap.sh --apiserver-endpoint '${endpoint}' --b64-cluster-ca '${certificate_authority}' '${cluster_id}' ${extra_bootstrap_args} \
+--kubelet-extra-args \
+  "--node-labels=cluster=${cluster_id},instance-id=$id,ami-id=$ami,${extra_node_labels} \
+   --cloud-provider=aws ${extra_kubelet_args}"
+${extra_userdata}

--- a/example/00_backend_init/backend_init.tf
+++ b/example/00_backend_init/backend_init.tf
@@ -1,0 +1,24 @@
+locals {
+  region      = "ap-southeast-2"
+  owner       = "scr"
+  namespace   = "dpas"
+  environment = "sandbox"
+}
+
+module "backend_init" {
+  source = "../../backend_init"
+
+  owner       = local.owner
+  namespace   = local.namespace
+  environment = local.environment
+
+  # Additional Tags
+  tags = {
+    "stack_name" = "${local.namespace}-${local.environment}-eks"
+    "department" = "-"
+    "division"   = "-"
+    "branch"     = "-"
+    "cost_code"  = "-"
+    "project"    = "-"
+  }
+}

--- a/example/00_backend_init/output.tf
+++ b/example/00_backend_init/output.tf
@@ -1,0 +1,7 @@
+output "tf_state_bucket" {
+  value = module.backend_init.tf_state_bucket
+}
+
+output "tf_dynamodb_table" {
+  value = module.backend_init.tf_dynamodb_table
+}

--- a/example/00_backend_init/provider.tf
+++ b/example/00_backend_init/provider.tf
@@ -1,0 +1,4 @@
+provider "aws" {
+  region      = local.region
+  max_retries = 10
+}

--- a/example/01_dpas_eks/config/karpenter.yaml
+++ b/example/01_dpas_eks/config/karpenter.yaml
@@ -1,0 +1,10 @@
+clusterName: ${cluster_name}
+clusterEndpoint: ${cluster_endpoint}
+aws:
+  defaultInstanceProfile: ${instance_profile}
+#  interruptionQueueName: ${cluster_name}
+serviceAccount:
+  create: true
+  annotations:
+    eks.amazonaws.com/role-arn: ${service_account_arn}
+affinity: ${node_affinity}

--- a/example/01_dpas_eks/data_providers.tf
+++ b/example/01_dpas_eks/data_providers.tf
@@ -1,0 +1,121 @@
+module "cluster_label" {
+  source = "cloudposse/label/null"
+
+  namespace = local.namespace
+  stage     = local.environment
+  name      = "eks"
+  delimiter = "-"
+}
+
+data "aws_availability_zones" "available" {}
+data "aws_caller_identity" "current" {}
+data "aws_canonical_user_id" "current" {}
+data "aws_ecrpublic_authorization_token" "token" {
+  provider = aws.virginia
+}
+data "aws_eks_cluster" "cluster" {
+  name = module.dpas_eks_cluster.cluster_id
+}
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.dpas_eks_cluster.cluster_id
+}
+
+locals {
+  region      = "ap-southeast-2"
+  owner       = "scr"
+  namespace   = "dpas"
+  environment = "sandbox"
+
+  cluster_version = 1.23
+  cluster_id      = module.cluster_label.id
+
+  # VPC
+  enable_s3_endpoint    = true
+  enable_nat_gateway    = true
+  vpc_cidr              = "10.35.0.0/16"
+  public_subnet_cidrs   = ["10.35.0.0/22", "10.35.4.0/22", "10.35.8.0/22"]
+  private_subnet_cidrs  = ["10.35.32.0/19", "10.35.64.0/19", "10.35.96.0/19"]
+  database_subnet_cidrs = ["10.35.20.0/22", "10.35.24.0/22", "10.35.28.0/22"]
+
+  # EKS add-ons
+  cni_version        = "v1.11.3-eksbuild.1"
+  kube_proxy_version = "v1.23.7-eksbuild.1"
+  core_dns_version   = "v1.8.7-eksbuild.2"
+
+  # EKS Node
+  default_worker_instance_type = "m5.xlarge"
+  extra_bootstrap_args         = "--container-runtime containerd"
+  # node labels - can be use for node affinity configurations
+  default_node_group = "eks-default"
+  default_node_type  = "ondemand"
+  extra_node_labels  = "nodegroup=${local.default_node_group},nodetype=${local.default_node_type}"
+  # instance userdata
+  extra_userdata = <<-USERDATA
+  REGION=${local.region}
+  AWS_INSTANCE_ID=`curl -s http://169.254.169.254/latest/meta-data/instance-id`
+  EC2_NAME=SCR-DPAS-$HOSTNAME
+  ## Enable ssm-agent
+  #########################
+  sudo systemctl enable amazon-ssm-agent
+  sudo systemctl start amazon-ssm-agent
+  #########################
+  USERDATA
+
+  # k8s defaults
+  # k8s aws-auth for authentication
+  aws_iam_admin_users = {
+    # <user-name> = "arn:aws:iam::${data.aws_caller_identity.current.account_id}:user/<user-name>"
+  }
+  aws_iam_admin_roles = {
+    # <role> : "arn:aws:iam::${data.aws_caller_identity.current.account_id}:role/<role>"
+  }
+  create_admin_namespace = true # Used for karpenter deployment
+  # node affinity - Used for karpenter affinity configuration
+  default_node_affinity = {
+    nodeAffinity : {
+      requiredDuringSchedulingIgnoredDuringExecution : {
+        nodeSelectorTerms : [{
+          matchExpressions : [
+            {
+              key : "nodetype"
+              operator : "In"
+              values : [local.default_node_type]
+            },
+            {
+              key : "nodegroup"
+              operator : "In"
+              values : [local.default_node_group]
+            },
+          ]
+        }]
+      }
+    }
+  }
+
+  # Karpenter
+  enable_karpenter           = true
+  karpenter_namespace        = "flux-system"
+  karpenter_create_namespace = true
+  karpenter_release_name     = "karpenter"
+  karpenter_version          = "v0.17.0"
+
+  # Flux2
+  enable_flux2               = true
+  flux2_namespace            = "flux-system"
+  flux2_create_namespace     = true
+  flux2_version              = "1.5.1"
+  flux2_notification_version = "1.3.0"
+  flux2_sync_version         = "1.0.0"
+
+  # provide organisation tags
+  tags = {
+    "stack_name" = module.cluster_label.id
+    "department" = "-"
+    "division"   = "-"
+    "branch"     = "-"
+    "cost_code"  = "-"
+    "project"    = "-"
+  }
+}
+
+

--- a/example/01_dpas_eks/eks.tf
+++ b/example/01_dpas_eks/eks.tf
@@ -1,0 +1,78 @@
+locals {
+  # aws-auth
+  aws_auth_roles = concat(
+    [for role_name, role_arn in local.aws_iam_admin_roles : {
+      rolearn  = role_arn
+      username = role_name
+      groups   = ["system:masters", ]
+    }]
+  )
+  aws_auth_users = concat(
+    [for user_name, user_arn in local.aws_iam_admin_users : {
+      rolearn  = user_arn
+      username = user_name
+      groups   = ["system:masters", ]
+    }],
+  )
+}
+
+module "dpas_eks_cluster" {
+  source = "../../eks"
+
+  # Cluster config
+  cluster_id      = local.cluster_id
+  cluster_version = local.cluster_version
+
+  # Cluster logs - disabled
+  cluster_enabled_log_types           = []
+  create_cluster_cloudwatch_log_group = false
+
+  # Default Tags
+  owner       = local.owner
+  namespace   = local.namespace
+  environment = local.environment
+
+  # Additional Tags
+  tags = merge(
+    {
+      # Tag for Karpenter auto-discovery - subnets and security groups
+      "karpenter.sh/discovery" = local.cluster_id
+    },
+    local.tags
+  )
+
+  # VPC and subnets config
+  create_vpc            = "true"
+  vpc_cidr              = local.vpc_cidr
+  public_subnet_cidrs   = local.public_subnet_cidrs
+  private_subnet_cidrs  = local.private_subnet_cidrs
+  database_subnet_cidrs = local.database_subnet_cidrs
+
+  # Nodegroup config
+  # This ensures core services such as VPC CNI, CoreDNS, etc. are up and running
+  # so that Karpenter can be deployed and start managing compute capacity as required
+  default_worker_instance_type = local.default_worker_instance_type
+  min_nodes                    = 1
+  max_nodes                    = 2
+  extra_userdata               = local.extra_userdata
+  extra_bootstrap_args         = local.extra_bootstrap_args
+  extra_node_labels            = local.extra_node_labels
+
+  cluster_addons = {
+    coredns = {
+      resolve_conflicts = "OVERWRITE"
+      addon_version     = local.core_dns_version
+    }
+    kube-proxy = {
+      resolve_conflicts = "OVERWRITE"
+      addon_version     = local.kube_proxy_version
+    }
+    vpc-cni = {
+      resolve_conflicts = "OVERWRITE"
+      addon_version     = local.cni_version
+    }
+  }
+
+  aws_auth_users = local.aws_auth_users
+  aws_auth_roles = local.aws_auth_roles
+}

--- a/example/01_dpas_eks/flux2.tf
+++ b/example/01_dpas_eks/flux2.tf
@@ -1,0 +1,34 @@
+module "fluxcd_flux2" {
+  source = "../../fluxcd_flux2"
+  count  = local.enable_flux2 ? 1 : 0
+
+  cluster_id = local.cluster_id
+
+  flux2_namespace        = local.flux2_namespace
+  flux2_create_namespace = local.flux2_create_namespace
+
+  # flux chart installation versions
+  # Charts: https://github.com/fluxcd-community/helm-charts/tree/main/charts
+  flux2_version              = local.flux2_version
+  flux2_notification_version = local.flux2_notification_version
+  flux2_sync_version         = local.flux2_sync_version
+
+  # flux sync configurations
+  # NOTE: Update as per your setup!
+  flux2_git_repo_url = "ssh://git@github.com/ga-scr/dpas-k8s-example-deployment"
+  flux2_git_branch   = "main"
+  flux2_git_path     = "workspaces/dpas-sandbox"
+
+  # flux notification configurations
+  # NOTE: update as per your setup!
+  flux2_webhook_url     = "provide-webhook-url"
+  flux2_webhook_type    = "slack"
+  flux2_webhook_channel = "dpas-system-notifications"
+
+  # notification events for alerting
+  flux2_additional_alert_event_sources = []
+
+  depends_on = [
+    module.dpas_eks_cluster.cluster_id
+  ]
+}

--- a/example/01_dpas_eks/flux2.tf
+++ b/example/01_dpas_eks/flux2.tf
@@ -6,6 +6,7 @@ module "fluxcd_flux2" {
 
   flux2_namespace        = local.flux2_namespace
   flux2_create_namespace = local.flux2_create_namespace
+  flux2_node_affinity    = local.default_node_affinity
 
   # flux chart installation versions
   # Charts: https://github.com/fluxcd-community/helm-charts/tree/main/charts

--- a/example/01_dpas_eks/karpenter.tf
+++ b/example/01_dpas_eks/karpenter.tf
@@ -1,0 +1,112 @@
+# Reference docs:
+## https://karpenter.sh/v0.19.3/getting-started/getting-started-with-eksctl/
+## https://karpenter.sh/v0.19.3/getting-started/migrating-from-cas/
+
+data "aws_iam_policy_document" "karpenter_controller_trust_policy" {
+  count = local.enable_karpenter ? 1 : 0
+  statement {
+    actions = [
+      "ec2:TerminateInstances"
+    ]
+    resources = ["*"]
+    condition {
+      test     = "StringLike"
+      variable = "ec2:ResourceTag/Name"
+
+      values = [
+        "*karpenter*"
+      ]
+    }
+    sid = "ConditionalEC2Termination"
+  }
+
+  statement {
+    actions = [
+      "ssm:GetParameter",
+      "iam:PassRole",
+      "ec2:RunInstances",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeLaunchTemplates",
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceTypes",
+      "ec2:DescribeInstanceTypeOfferings",
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DeleteLaunchTemplate",
+      "ec2:CreateTags",
+      "ec2:CreateLaunchTemplate",
+      "ec2:CreateFleet",
+      "ec2:DescribeSpotPriceHistory",
+      "pricing:GetProducts"
+    ]
+    resources = ["*"]
+    sid       = "Karpenter"
+  }
+}
+
+module "role_karpenter_controller" {
+  source = "../../k8s_service_account_role"
+  count  = local.enable_karpenter ? 1 : 0
+
+  # Default Tags
+  owner       = local.owner
+  namespace   = local.namespace
+  environment = local.environment
+
+  oidc_arn = module.dpas_eks_cluster.oidc_arn
+  oidc_url = module.dpas_eks_cluster.oidc_url
+
+  # Additional Tags
+  tags = local.tags
+
+  service_account_role = {
+    name                      = "svc-${local.cluster_id}-karpenter-controller"
+    service_account_namespace = local.karpenter_namespace
+    service_account_name      = "*"
+    policy                    = data.aws_iam_policy_document.karpenter_controller_trust_policy.0.json
+  }
+
+  depends_on = [
+    module.dpas_eks_cluster.cluster_id,
+  ]
+}
+
+resource "helm_release" "karpenter" {
+  count = local.enable_karpenter ? 1 : 0
+
+  name      = local.karpenter_release_name
+  namespace = local.karpenter_namespace
+
+  create_namespace = local.karpenter_create_namespace
+
+  repository          = "oci://public.ecr.aws/karpenter"
+  repository_username = data.aws_ecrpublic_authorization_token.token.user_name
+  repository_password = data.aws_ecrpublic_authorization_token.token.password
+  chart               = "karpenter"
+  version             = local.karpenter_version
+
+  values = [
+    templatefile("${path.module}/config/karpenter.yaml", {
+      node_affinity       = jsonencode(local.default_node_affinity)
+      cluster_name        = data.aws_eks_cluster.cluster.id
+      cluster_endpoint    = data.aws_eks_cluster.cluster.endpoint
+      region              = local.region
+      service_account_arn = module.role_karpenter_controller.0.role_arn
+      instance_profile    = module.dpas_eks_cluster.node_instance_profile
+    })
+  ]
+
+  lifecycle {
+    ignore_changes = [
+      repository_password,
+    ]
+  }
+
+  depends_on = [
+    module.dpas_eks_cluster.cluster_id,
+    module.role_karpenter_controller
+  ]
+}
+
+
+

--- a/example/01_dpas_eks/karpenter_provisioners.tf
+++ b/example/01_dpas_eks/karpenter_provisioners.tf
@@ -1,0 +1,89 @@
+resource "kubectl_manifest" "karpenter_provisioner_default_ondemand" {
+  count = local.enable_karpenter ? 1 : 0
+  yaml_body = <<-YAML
+    apiVersion: karpenter.sh/v1alpha5
+    kind: Provisioner
+    metadata:
+      name: default-ondemand
+    spec:
+      labels:
+        nodetype: ondemand
+        nodegroup: default
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["on-demand"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64", "arm64"]
+        - key: node.kubernetes.io/instance-type
+          operator: In
+          values:
+            - m6g.large
+            - m6g.xlarge
+            - m5.large
+            - m5.xlarge
+      limits:
+        resources:
+          cpu: 1000
+      providerRef:
+        name: default
+      ttlSecondsAfterEmpty: 60
+  YAML
+
+  depends_on = [
+    helm_release.karpenter
+  ]
+}
+
+resource "kubectl_manifest" "karpenter_provisioner_default_spot" {
+  count = local.enable_karpenter ? 1 : 0
+
+  yaml_body = <<-YAML
+    apiVersion: karpenter.sh/v1alpha5
+    kind: Provisioner
+    metadata:
+      name: default-spot
+    spec:
+      labels:
+        nodetype: spot
+        nodegroup: default
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot"]
+      limits:
+        resources:
+          cpu: 1000
+      providerRef:
+        name: default
+      ttlSecondsAfterEmpty: 60
+  YAML
+
+  depends_on = [
+    helm_release.karpenter
+  ]
+}
+
+resource "kubectl_manifest" "karpenter_node_template" {
+  count = local.enable_karpenter ? 1 : 0
+
+  yaml_body = <<-YAML
+    apiVersion: karpenter.k8s.aws/v1alpha1
+    kind: AWSNodeTemplate
+    metadata:
+      name: default
+    spec:
+      subnetSelector:
+        karpenter.sh/discovery: ${local.cluster_id}
+      securityGroupSelector:
+        karpenter.sh/discovery: ${local.cluster_id}
+      tags:
+        karpenter.sh/discovery: ${local.cluster_id}
+  YAML
+
+  depends_on = [
+    helm_release.karpenter
+  ]
+}
+

--- a/example/01_dpas_eks/main.tf
+++ b/example/01_dpas_eks/main.tf
@@ -1,0 +1,17 @@
+terraform {
+  backend "s3" {
+    bucket         = "dpas-sandbox-backend-tfstate"
+    key            = "dpas_eks_terraform.tfstate"
+    region         = "ap-southeast-2"
+    dynamodb_table = "dpas-sandbox-backend-tflock"
+    # Force encryption
+    encrypt = true
+  }
+
+  required_providers {
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.10.0"
+    }
+  }
+}

--- a/example/01_dpas_eks/outputs.tf
+++ b/example/01_dpas_eks/outputs.tf
@@ -1,0 +1,47 @@
+output "cluster_id" {
+  value = module.dpas_eks_cluster.cluster_id
+}
+
+output "region" {
+  value = local.region
+}
+
+output "owner" {
+  value = local.owner
+}
+
+output "namespace" {
+  value = local.namespace
+}
+
+output "environment" {
+  value = local.environment
+}
+
+output "node_role_arn" {
+  value = module.dpas_eks_cluster.node_role_arn
+}
+
+output "node_role_name" {
+  value = module.dpas_eks_cluster.node_role_name
+}
+
+output "node_instance_profile" {
+  value = module.dpas_eks_cluster.node_instance_profile
+}
+
+output "node_security_group" {
+  value = module.dpas_eks_cluster.node_security_group
+}
+
+output "oidc_arn" {
+  value = module.dpas_eks_cluster.oidc_arn
+}
+
+output "oidc_url" {
+  value = module.dpas_eks_cluster.oidc_url
+}
+
+output "tags" {
+  value = local.tags
+}

--- a/example/01_dpas_eks/provider.tf
+++ b/example/01_dpas_eks/provider.tf
@@ -1,0 +1,31 @@
+provider "aws" {
+  region      = "ap-southeast-2"
+  max_retries = 10
+}
+
+provider "aws" {
+  region = "us-east-1"
+  alias  = "virginia"
+}
+
+provider "kubernetes" {
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}
+
+provider "helm" {
+  kubernetes {
+    host                   = data.aws_eks_cluster.cluster.endpoint
+    cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+  }
+}
+
+provider "kubectl" {
+  apply_retry_count      = 5
+  host                   = data.aws_eks_cluster.cluster.endpoint
+  cluster_ca_certificate = base64decode(data.aws_eks_cluster.cluster.certificate_authority.0.data)
+  load_config_file       = false
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,86 @@
+# Live Examples to exercise this suite of Terraform Modules
+
+## Usage
+- Select the correct AWS credentials to use with sufficient privileges to spin up the infrastructure, e.g. `export AWS_PROFILE=admin`
+- Create a backend to store terraform state if requires. There is an example provided under `examples/00_backend_int` that creates the s3 bucket to store terraform state and the dynamodb table to store terraform state lock.
+- To create a full eks infrastructure on AWS platform, execute `examples/01_dpas_eks` module. Please note that the number in front, e.g. `00_ / 01_`, represents the correct order of execution to manage dependencies.
+- Adjust some configuration params such as `owner`, `namespace`, `environment`, `region` and `terraform backend` - so they are unique to your organisation.
+
+## Create your live repo
+
+This repo provides terraform modules required to setup a DPAS processing EKS cluster on AWS platform.
+
+## Create terraform backend
+
+We store the current state of the infrastructure on an AWS S3 bucket to ensure terraform knows what infrastructure it
+has created, even if something happens to the machine.
+
+We also use a simple dynamodb table as a lock to ensure multiple people can't make a deployment at the same time.
+
+To set up this infrastructure, you'll need to adjust the following local variables in `examples/00_backend_init/backend_init.tf`
+
+| Variable      | Description                                                                     | Default            |
+|:--------------|:--------------------------------------------------------------------------------|--------------------|
+| `region`      | The AWS region to provision resources                                           | `"ap-southeast-2"` |
+| `owner`       | The owner of the environment                                                    | `"scr"`            |
+| `namespace`   | The name used for creation of backend resources like the terraform state bucket | `"dpas"`           |
+| `environment` | The name of the environment - e.g. `dev`, `sandbox`, `prod`                     | `"sandbox"`        |
+| `tags`        | Supply tags as per your organisation need                                       |                    |
+
+The `namespace` and `environment` combination needs to be unique for your project. This is used for resource naming convention to support multiple environments in given AWS accounts.
+Supply tags will be applied to all the resources provision by live repo. 
+
+Run these commands in order to create the required infrastructure to store terraform state:
+
+```shell script
+  cd examples/00_backend_init
+  terraform init
+  terraform plan
+  terraform apply
+```
+
+Terraform will create the required resources, at the end you'll see:
+
+> `Apply complete!`
+
+
+```properties
+tf-state-bucket="${namespace}-${environment}-backend-tfstate"
+dynamodb_table="${namespace}-${environment}-backend-terraform-lock"
+```
+
+Congratulations you're all setup and ready to build your first cluster!
+
+## Creating your first cluster
+
+Once you have created terraform backend, you can perform the following steps to setup a new DPAS cluster environment -
+
+- Change directory to `examples/01_dpas_eks/`
+- Adjust the following local variables in `data_providers.tf`
+
+| Variable      | Description                                                                     | Default            |
+|:--------------|:--------------------------------------------------------------------------------|--------------------|
+| `region`      | The AWS region to provision resources                                           | `"ap-southeast-2"` |
+| `owner`       | The owner of the environment                                                    | `"scr"`            |
+| `namespace`   | The name used for creation of backend resources like the terraform state bucket | `"dpas"`           |
+| `environment` | The name of the environment - e.g. `dev`, `sandbox`, `prod`                     | `"sandbox"`        |
+| `tags`        | Supply tags as per your organisation need                                       |                    |
+    
+- This module optionally deploys karpenter and flux2 related AWS resources and helm release. You can turn it off by setting `enable_karpenter` and `enable_flux2` flags to `false` in `data_providers.tf` 
+- Modify `main.tf`:
+    - `bucket`: `<namespace>-<environment>-backend-tfstate`
+    - `dynamodb_table`: `<namespace>-<environment>-backend-tflock`
+    - `region` : `<region>`
+- Run `terraform init` to initialize Terraform state tracking
+- Run `terraform plan` to do a dry run and validate examples and interaction of modules
+- Run `terraform apply` to spin up infrastructure -- can take upto 15-20 minutes
+- Validate a fresh kubernetes cluster has been created by adding a new kubernetes context and getting clusterinfo
+
+Congratulations you're all setup with DPAS EKS cluster for kubernetes workloads and applications.
+
+To Destroy all terraform infrastructure run below command. 
+```shell script
+  cd examples/01_dpas_eks
+  terraform init
+  terraform destroy
+```

--- a/fluxcd_flux2/README.md
+++ b/fluxcd_flux2/README.md
@@ -1,0 +1,74 @@
+# Terraform Open Data Cube FluxCD Flux2 Installation
+
+The purpose of this module is to set up [FluxCD](https://fluxcd.io/docs/) [Flux version 2](https://github.com/fluxcd/flux2)
+- a tool for keeping Kubernetes clusters in sync with sources of configuration (like Git repositories),
+and automating updates to configuration when there is new code to deploy.
+
+---
+
+```hcl-terraform
+module "fluxcd_flux2" {
+  source = "git@github.com:ga-scr/dpas-terraform-modules.git//fluxcd_flux2?ref=main"
+
+  cluster_id      = local.cluster_id
+  
+  flux2_create_namespace = true  # Let's module to create a namespace
+  flux2_namespace        = "flux-system"
+
+  # flux chart installation versions
+  # Charts: https://github.com/fluxcd-community/helm-charts/tree/main/charts
+  flux2_version              = local.flux2_version
+  flux2_notification_version = local.flux2_notification_version
+  flux2_sync_version         = local.flux2_sync_version
+
+  # flux sync configurations
+  flux2_git_repo_url = "ssh://git@github.com/ga-scr/dpas-k8s-example-deployments"
+  flux2_git_branch   = "main"
+  flux2_git_path     = "workspaces/dpas"
+
+  # flux notification configurations - e.g. slack channel
+  flux2_webhook_url     = "<slack-url>"
+  flux2_webhook_channel = "scr-dpas-flux"
+  flux2_webhhok_type    = "slack"
+
+  # notification events for alerting
+  flux2_additional_alert_event_sources = []
+}
+```
+
+## Variables
+
+### Inputs
+| Name                                 | Description                                                                                                                                                        |  Type  | Default | Required |
+|--------------------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------------|:------:|:-------:|:--------:|
+| cluster_id                           | EKS Cluster name                                                                                                                                                   | string |         |   Yes    |
+| flux2_create_namespace               | Determines whether to create k8s namespace. Default is set to true and creates a namespace resource provided in `flux2_namespace` var                              |  bool  |  true   |    No    |
+| flux2_namespace                      | k8s namespace to install flux v2 components                                                                                                                        | string |         |   Yes    |
+| flux2_node_affinity                  | Kubernetes node affinity configuration to constrain flux2 components can be scheduled on                                                                           |  any   |   {}    |    No    |
+| flux2_version                        | flux V2 chart version                                                                                                                                              | string |         |    No    |
+| flux2_notification_version           | flux V2 notification chart version                                                                                                                                 | string |         |    No    |
+| flux2_sync_version                   | flux V2 sync chart version                                                                                                                                         | string |         |    No    |
+| flux2_git_repo_url                   | URL pointing to the git repository that flux will monitor and commit to                                                                                            | string |         |   Yes    |
+| flux2_git_branch                     | Branch of the specified git repository to monitor and commit to                                                                                                    | string |         |   Yes    |
+| flux2_git_path                       | Relative path inside specified git repository to search for manifest files                                                                                         | string |         |   Yes    |
+| flux2_git_poll_interval              | Period at which to poll git repo for new commits                                                                                                                   | string |   1m    |    No    |
+| flux2_git_timeout                    | Duration after which git operations time out                                                                                                                       | string |   20s   |    No    |
+| flux2_webhook_url                    | Webhook URL for flux notification                                                                                                                                  | string |         |   Yes    |
+| flux2_webhook_channel                | Channel name for flux notification                                                                                                                                 | string |         |   Yes    |
+| flux2_webhook_type                   | Alert type for flux notification e.g. slack, msteams, etc                                                                                                          | string |         |   Yes    |
+| flux2_additional_alert_event_sources | A list of alerts to be used for notification. Flux2 already monitors 'GitRepository', 'Kustomization' and 'HelmRelease' Kubernetes resources under flux2 namespace |  list  |         |    No    |
+
+## Issues
+
+* The first time installation fail for `flux2_sync` and `flux2_slack_notification` 
+
+The `flux2_sync` and `flux2_slack_notification` helmreleases depends on `flux2` components to be installed.
+This is provisioned using `flux2` helmrelease resource in the same apply. However, this dependency hasn't been managed properly.
+So by rerunning a pipeline again should fix the issue.
+
+If issue still persist, then uninstall flux using [fluxcli](https://fluxcd.io/docs/cmd/) and bootstrap the process again.
+
+```
+> flux uninstall
+> flux check
+```

--- a/fluxcd_flux2/config/flux2.yaml
+++ b/fluxcd_flux2/config/flux2.yaml
@@ -1,0 +1,26 @@
+helmcontroller:
+  create: true
+  affinity: ${node_affinity}
+
+imageautomationcontroller:
+  create: true
+  affinity: ${node_affinity}
+
+imagereflectorcontroller:
+  create: true
+  container:
+    additionalargs:
+    - --aws-autologin-for-ecr
+  affinity: ${node_affinity}
+
+kustomizecontroller:
+  create: true
+  affinity: ${node_affinity}
+
+notificationcontroller:
+  create: true
+  affinity: ${node_affinity}
+
+sourcecontroller:
+  create: true
+  affinity: ${node_affinity}

--- a/fluxcd_flux2/config/flux2_notification.yaml
+++ b/fluxcd_flux2/config/flux2_notification.yaml
@@ -1,0 +1,25 @@
+secretlist:
+  - name: ${webhook_channel}-url
+    value:
+      data:
+        address: "${webhook_address}"
+
+providerlist:
+  - name: ${webhook_type}
+    spec:
+      type: ${webhook_type}
+      channel: ${webhook_channel}
+      secretRef:
+        name: ${webhook_channel}-url
+      certSecretRef: {}
+
+alertlist:
+  - name: cluster-alerts
+    spec:
+      providerRef:
+        name: ${webhook_type}
+      eventSeverity: info
+      eventSources: ${alert_event_sources}
+      exclusionList:
+        - "waiting.*socket"
+        - "^Dependencies.*"

--- a/fluxcd_flux2/config/flux2_sync.yaml
+++ b/fluxcd_flux2/config/flux2_sync.yaml
@@ -1,0 +1,18 @@
+secret:
+  # -- Create a secret for the git repository. Defaults to false.
+  create: false
+
+gitRepository:
+  spec:
+    url: "${git_repo_url}"
+    # The secret name containing the Git credentials.
+    secretRef:
+      name: "${flux_git_secret}"
+    ref:
+      branch: "${git_branch}"
+kustomization:
+  spec:
+    interval: "${git_poll_interval}"
+    path: "${git_path}"
+    prune: true
+    timeout: "${git_timeout}"

--- a/fluxcd_flux2/flux_v2.tf
+++ b/fluxcd_flux2/flux_v2.tf
@@ -1,0 +1,106 @@
+# SSH
+locals {
+  known_hosts = "github.com ecdsa-sha2-nistp256 AAAAE2VjZHNhLXNoYTItbmlzdHAyNTYAAAAIbmlzdHAyNTYAAABBBEmKSENjQEezOmxkZMy7opKgwFB9nkt5YRrYMjNuG5N87uRgg6CLrbo5wAdT/y6v0mKV0U2w0WZ2YB/++Tpockg="
+
+  default_alert_event_sources = [
+    {
+      kind : "GitRepository"
+      name : "*"
+      namespace : var.flux2_namespace
+    },
+    {
+      kind : "Kustomization"
+      name : "*"
+      namespace : var.flux2_namespace
+    },
+    {
+      kind : "HelmRelease"
+      name : "*"
+      namespace : var.flux2_namespace
+    },
+  ]
+}
+
+resource "tls_private_key" "flux2" {
+  algorithm   = "ECDSA"
+  ecdsa_curve = "P256"
+}
+
+# Generate a Kubernetes secret with the Git credentials
+resource "kubernetes_secret" "flux2" {
+  depends_on = [helm_release.flux2]
+
+  metadata {
+    name      = "flux-system"
+    namespace = var.flux2_namespace
+  }
+
+  data = {
+    identity       = tls_private_key.flux2.private_key_pem
+    "identity.pub" = tls_private_key.flux2.public_key_pem
+    known_hosts    = local.known_hosts
+    # GitHub Deploy Key
+    public_key_openssh = tls_private_key.flux2.public_key_openssh
+  }
+}
+
+## Install flux using helm charts: https://github.com/fluxcd-community/helm-charts/
+# Chart: https://github.com/fluxcd-community/helm-charts/tree/main/charts/flux2
+# https://fluxcd.io/docs/components/
+resource "helm_release" "flux2" {
+  name       = "${var.cluster_id}-flux2"
+  repository = "https://fluxcd-community.github.io/helm-charts"
+  chart      = "flux2"
+  version    = var.flux2_version
+
+  namespace        = var.flux2_namespace
+  create_namespace = var.flux2_create_namespace
+
+  values = [
+    templatefile("${path.module}/config/flux2.yaml", {
+      node_affinity = jsonencode(var.flux2_node_affinity)
+    })
+  ]
+}
+
+# Chart: https://github.com/fluxcd-community/helm-charts/tree/main/charts/flux2-sync
+# https://fluxcd.io/docs/components/source/gitrepositories/
+resource "helm_release" "flux2_sync" {
+  depends_on = [helm_release.flux2]
+  name       = "${var.cluster_id}-deployer"
+  repository = "https://fluxcd-community.github.io/helm-charts"
+  chart      = "flux2-sync"
+  version    = var.flux2_sync_version
+  namespace  = var.flux2_namespace
+
+  values = [
+    templatefile("${path.module}/config/flux2_sync.yaml", {
+      git_repo_url      = var.flux2_git_repo_url
+      git_branch        = var.flux2_git_branch
+      git_path          = var.flux2_git_path
+      git_poll_interval = var.flux2_git_poll_interval
+      git_timeout       = var.flux2_git_timeout
+      flux_git_secret   = kubernetes_secret.flux2.metadata[0].name
+    })
+  ]
+}
+
+# Chart: https://github.com/fluxcd-community/helm-charts/tree/main/charts/flux2-notification
+# https://fluxcd.io/docs/components/notification/
+resource "helm_release" "flux2_notification" {
+  depends_on = [helm_release.flux2]
+  name       = "${var.cluster_id}-flux2-notification"
+  repository = "https://fluxcd-community.github.io/helm-charts"
+  chart      = "flux2-notification"
+  version    = var.flux2_notification_version
+  namespace  = var.flux2_namespace
+
+  values = [
+    templatefile("${path.module}/config/flux2_notification.yaml", {
+      webhook_address     = base64encode(var.flux2_webhook_url)
+      webhook_channel     = var.flux2_webhook_channel
+      webhook_type        = var.flux2_webhook_type
+      alert_event_sources = jsonencode(distinct(concat(local.default_alert_event_sources, var.flux2_additional_alert_event_sources)))
+    })
+  ]
+}

--- a/fluxcd_flux2/variables.tf
+++ b/fluxcd_flux2/variables.tf
@@ -1,0 +1,94 @@
+variable "cluster_id" {
+  description = "EKS Cluster name"
+  type        = string
+}
+
+variable "flux2_namespace" {
+  type        = string
+  description = "k8s namespace to install flux v2 components"
+  default     = "flux-system"
+}
+
+variable "flux2_create_namespace" {
+  type        = bool
+  description = "Determines whether to create k8s namespace for flux2 components"
+  default     = true
+}
+
+variable "flux2_node_affinity" {
+  type        = any
+  description = "Kubernetes node affinity configuration to constrain flux2 components can be scheduled on"
+  default     = {}
+}
+
+variable "flux2_version" {
+  type        = string
+  description = "flux V2 chart version"
+  default     = "0.15.0"
+}
+
+variable "flux2_notification_version" {
+  type        = string
+  description = "flux V2 notification chart version"
+  default     = "0.5.2"
+}
+
+variable "flux2_sync_version" {
+  type        = string
+  description = "flux V2 sync chart version"
+  default     = "0.3.6"
+}
+
+variable "flux2_git_repo_url" {
+  type        = string
+  description = "URL pointing to the git repository that flux will monitor and commit to"
+  default     = ""
+}
+
+variable "flux2_git_branch" {
+  type        = string
+  description = "Branch of the specified git repository to monitor and commit to"
+  default     = ""
+}
+
+variable "flux2_git_path" {
+  type        = string
+  description = "Relative path inside specified git repository to search for manifest files"
+  default     = ""
+}
+
+variable "flux2_git_poll_interval" {
+  type        = string
+  description = "Period at which to poll git repo for new commits"
+  default     = "1m"
+}
+
+variable "flux2_git_timeout" {
+  type        = string
+  description = "Duration after which git operations time out"
+  default     = "20s"
+}
+
+variable "flux2_webhook_url" {
+  type        = string
+  description = "Webhook URL for flux notification"
+  default     = ""
+}
+
+variable "flux2_webhook_channel" {
+  type        = string
+  description = "Channel name for flux notification"
+  default     = ""
+}
+
+variable "flux2_webhook_type" {
+  type        = string
+  description = "Alert type for flux notification e.g. slack, msteams, etc"
+  default     = ""
+}
+
+variable "flux2_additional_alert_event_sources" {
+  type        = list(any)
+  description = "A list of alerts to be used for notification"
+  default     = []
+}

--- a/k8s_service_account_role/README.md
+++ b/k8s_service_account_role/README.md
@@ -1,0 +1,115 @@
+# Terraform Module: k8s_service_account_role
+
+The purpose of this module is to provision IAM roles to support service account role based access. 
+For more detail read - [Introducing fine-grained IAM roles for service accounts](https://aws.amazon.com/blogs/opensource/introducing-fine-grained-iam-roles-service-accounts/) 
+
+---
+
+## Introduction
+
+* Provide fine-grained roles at the pod level rather than the node level
+* No need to pass user credentials as long as the application is configured for service account web identity token based access
+
+## Usage
+
+First step is to provision service account role for k8s service account like -
+
+```terraform
+module "svc_role_alb_controller" {
+  source = "git@github.com:ga-scr/dpas-terraform-modules.git//k8s_service_account_role?ref=main"
+
+  # Default Tags
+  owner       = local.owner
+  namespace   = local.namespace
+  environment = local.environment
+
+  #OIDC
+  oidc_arn = local.oidc_arn
+  oidc_url = local.oidc_url
+
+  # Additional Tags
+  tags = local.tags
+
+  # service account role used in processing namespace
+  service_account_role = {
+    name                      = "svc-${local.cluster_id}-foo-sa"
+    service_account_namespace = "processing"
+    service_account_name      = "*"
+    policy                    = <<-EOF
+      {
+        "Version": "2012-10-17",
+        "Statement": [
+          {
+            "Effect": "Allow",
+            "Action": ["S3:ListBucket"],
+            "Resource": [
+              "arn:aws:s3:::dea-public-data"
+            ]
+          },
+          {
+            "Effect": "Allow",
+            "Action": ["S3:GetObject"],
+            "Resource": [
+              "arn:aws:s3:::dea-public-data/*"
+            ]
+          }
+        ]
+      }
+    EOF
+  }
+}
+```
+
+This role then be used by k8s service-account using `eks.amazonaws.com/role-arn` annotation. 
+Alternatively, you can configure service-account and assign a service-account to pod/deployment. 
+This will then pass `AWS_ROLE_ARN` and `AWS_WEB_IDENTITY_TOKEN_FILE` environment variables to the pod.
+Then configure a pod to assumes the IAM role using `sts:AssumeRoleWithWebIdentity`.
+
+```yaml
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: foo-sa
+  namespace: processing
+  annotations:
+    eks.amazonaws.com/role-arn: arn:aws:iam::<account-id>:role/svc-<cluster_id>-foo-sa
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: foo-sa-processing
+  namespace: processing
+  labels:
+    app: foo-sa-processing
+spec:
+  selector:
+    matchLabels:
+      app: foo-sa-processing
+  template:
+    metadata:
+      labels:
+        app: foo-sa-processing
+    spec:
+      serviceAccountName: foo-sa
+  container:
+    ...
+```
+
+## Variables
+
+### Inputs
+| Name                 | Description                                                                            |    Type     |       Default        | Required |
+|----------------------|----------------------------------------------------------------------------------------|:-----------:|:--------------------:|:--------:|
+| owner                | The owner of the owner - e.g. scr                                                      |   string    |                      |   Yes    |
+| namespace            | The unique namespace for the environment, which could be branch abbreviation e.g. dpas |   string    |                      |   Yes    |
+| environment          | The name of the environment - e.g. dev, stage, prod                                    |   string    |                      |   Yes    |
+| oidc_arn             | The arn of the OpenId connect provider associated with this cluster                    |   string    |                      |   Yes    |
+| oidc_url             | The url of the OpenId connect provider associated with this cluster                    |   string    |                      |   Yes    |
+| service_account_role | Specify custom IAM roles that can be used by pods on the k8s cluster                   |     map     | [see example above]  |   Yes    |
+| tags                 | Additional tags - e.g. `map('StackName','XYZ')`                                        | map(string) |          {}          |    No    |
+
+### Outputs
+| Name      | Description               | Sensitive |
+|-----------|---------------------------|-----------|
+| role_name | Service account role name | false     |
+| role_arn  | Service account role ARN  | false     |

--- a/k8s_service_account_role/output.tf
+++ b/k8s_service_account_role/output.tf
@@ -1,0 +1,7 @@
+output "role_name" {
+  value = aws_iam_role.service_account_role.name
+}
+
+output "role_arn" {
+  value = aws_iam_role.service_account_role.arn
+}

--- a/k8s_service_account_role/role.tf
+++ b/k8s_service_account_role/role.tf
@@ -1,0 +1,45 @@
+locals {
+  max_session_duration = lookup(var.service_account_role, "max_session_duration", 3600)
+}
+
+data "aws_iam_policy_document" "trust_policy" {
+  statement {
+    sid = "1"
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    principals {
+      type        = "Federated"
+      identifiers = [var.oidc_arn]
+    }
+
+    condition {
+      test     = (var.service_account_role.service_account_name != "*") ? "StringEquals" : "StringLike"
+      variable = "${replace(var.oidc_url, "https://", "")}:sub"
+      values = [
+        "system:serviceaccount:${var.service_account_role.service_account_namespace}:${var.service_account_role.service_account_name}"
+      ]
+    }
+  }
+}
+
+resource "aws_iam_role" "service_account_role" {
+  name                 = var.service_account_role.name
+  assume_role_policy   = data.aws_iam_policy_document.trust_policy.json
+  max_session_duration = local.max_session_duration
+  tags = merge(
+    {
+      name        = var.service_account_role.name
+      owner       = var.owner
+      namespace   = var.namespace
+      environment = var.environment
+    },
+    var.tags
+  )
+}
+
+resource "aws_iam_role_policy" "service_account_role_policy" {
+  name   = var.service_account_role.name
+  role   = aws_iam_role.service_account_role.id
+  policy = var.service_account_role.policy
+}

--- a/k8s_service_account_role/variables.tf
+++ b/k8s_service_account_role/variables.tf
@@ -1,0 +1,42 @@
+variable "owner" {
+  type        = string
+  description = "The owner of the owner - e.g. scr"
+}
+
+variable "namespace" {
+  type        = string
+  description = "The unique namespace for the environment, which could be branch abbreviation e.g. dpas"
+}
+
+variable "environment" {
+  type        = string
+  description = "The name of the environment - e.g. dev, stage, prod"
+}
+
+variable "oidc_arn" {
+  description = "The arn of the OpenId connect provider associated with this cluster"
+}
+
+variable "oidc_url" {
+  description = "The url of the OpenId connect provider associated with this cluster"
+}
+
+variable "service_account_role" {
+  type        = map(any)
+  description = "Specify custom IAM roles that can be used by pods on the k8s cluster"
+  # service_account_role = {
+  #     name  = "foo"
+  #     service_account_namespace = "foo-sa"
+  #     service_account_name = "foo-sa"    # put "*" to scope a role to an entire namespace
+  #     policy = <<-EOF
+  #       IAMPolicyDocument
+  #       WithIdents
+  #     EOF
+  # }
+}
+
+variable "tags" {
+  type        = map(string)
+  description = "Additional tags (e.g. `map('StackName','XYZ')`"
+  default     = {}
+}


### PR DESCRIPTION
-> Below listed terraform modules are open sourced to support DPAS processing cloud setup on AWS
- `backend_init` - module to provision backend resources (ie s3 and dynamodb table) to manage terraform state files
- `eks` - module to provision complete EKS cluster on AWS (optionally VPC)
- `fluxcd_flux2` - module to set up [FluxCD](https://fluxcd.io/docs/) [Flux version 2](https://github.com/fluxcd/flux2)
- `k8s_service_account_role` - module to provision IAM roles to support service account role based access

-> provided example to exercise this suite of Terraform Modules
