### PR TITLE
Upgrade vpc module

### DIFF
--- a/eks/master_addons.tf
+++ b/eks/master_addons.tf
@@ -4,10 +4,11 @@ resource "aws_eks_addon" "eks_addons" {
   cluster_name = aws_eks_cluster.eks.name
   addon_name   = try(each.value.name, each.key)
 
-  addon_version            = lookup(each.value, "addon_version", null)
-  resolve_conflicts        = lookup(each.value, "resolve_conflicts", null)
-  service_account_role_arn = lookup(each.value, "service_account_role_arn", null)
-  configuration_values     = lookup(each.value, "configuration_values", null)
+  addon_version               = lookup(each.value, "addon_version", null)
+  resolve_conflicts_on_create = lookup(each.value, "resolve_conflicts", null)
+  resolve_conflicts_on_update = lookup(each.value, "resolve_conflicts", null)
+  service_account_role_arn    = lookup(each.value, "service_account_role_arn", null)
+  configuration_values        = lookup(each.value, "configuration_values", null)
 
   depends_on = [
     aws_autoscaling_group.node,

--- a/eks/vpc.tf
+++ b/eks/vpc.tf
@@ -2,7 +2,7 @@
 ##############################
 module "vpc" {
   source  = "terraform-aws-modules/vpc/aws"
-  version = "v3.14.2"
+  version = "v4.0.2"
 
   count = var.create_vpc ? 1 : 0
 

--- a/eks/vpc.tf
+++ b/eks/vpc.tf
@@ -32,7 +32,15 @@ module "vpc" {
   enable_dns_hostnames = true
   enable_dns_support   = true
 
-  enable_nat_gateway = true
+  # One NAT Gateway per subnet (default behavior)
+  enable_nat_gateway     = true
+  single_nat_gateway     = false
+  one_nat_gateway_per_az = false
+
+  manage_default_network_acl    = false
+  manage_default_route_table    = false
+  manage_default_security_group = false
+  map_public_ip_on_launch       = false
 
   create_database_subnet_group = var.create_database_subnet_group
   database_subnet_group_name   = var.database_subnet_group_name


### PR DESCRIPTION
There is a new Terraform AWS provider [release](https://github.com/hashicorp/terraform-provider-aws/blob/main/CHANGELOG.md) (new version 5.1.0 released last week) that has impacted our VPC/EKS module so this PR:
- VPC module- upgrade module version and adjust some of its configurations - no impact to our current VPC setup
- eks addons - resolve_conflicts is deprecated; switch to use resolve_conflicts_on_create and resolve_conflicts_on_update